### PR TITLE
Auto install safety for pipenv check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ruff: # Run 'ruff' linter and print a preview of errors
 	pipenv run ruff check .
 
 safety: # Check for security vulnerabilities and verify Pipfile.lock is up-to-date
-	pipenv check
+	pipenv check --auto-install
 	pipenv verify
 
 lint-apply: # Apply changes with 'black' and resolve 'fixable errors' with 'ruff'


### PR DESCRIPTION
### Purpose and background context

As of `pipenv 2025.0.1`, the `check` command is deprecated and not fully supported.  Related, the package `safety` is no longer installed by default.  It appears that going forward, an API key may be required and the command `scan` is preferred.

However, in the short term, `pipenv check` can still be used by including `--auto-install` as part of the command to install the library `safety` without modifying the `Pipefile` or `Pipfile.lock`.

[Read more here in this confluence page](https://mitlibraries.atlassian.net/wiki/spaces/~712020891b98ee715c482a8101f080ef16e887/blog/2025/04/24/4562747397/pipenv+2025.0.1+and+safety).

How this addresses that need:
* Update the `Makefile` to include `--auto-install` for `pipenv check' command

Side effects of this change:
* Github Actions builds continue to function
* Short-term solution for pipenv check

Relevant ticket(s):
* None

### How can a reviewer manually see the effects of these changes?

Monitor Github Actions linting for success.

### Includes new or updated dependencies?
NO*: an asterisk, because `safety` is installed during build but only temporarily; the `Pipfile` and `Pipfile.lock` are not modified

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes