### PR TITLE
IN 1230 - configurable workspace, use EFS mount

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pre-commit = "*"
 pytest = "*"
 ruff = "*"
 types-jsonschema = "*"
+pytest-mock = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0efc7c681893c033e33d1de90be62cca02b42a1141dc0bae68e287d4eabfa82a"
+            "sha256": "2560894c94f2c81c6f173a87ce0328a228c52290b389b59fa85159252a02565d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,20 +34,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:26113a47d549bc3c46dbf56c8ab74f272c3da55df23e2c460fcf3c6c64d54dce",
-                "sha256:af4c78a3faa1a56cbaeb9e06cd5580772138be519fc6e740b81db586d5d1910c"
+                "sha256:2cba851374c9b15facd6e7fe3adf7988c216537182d2c139e96da5c101f4cbcf",
+                "sha256:44bc15285104683cd25dfb60abc5aac65b75d9e79b06f43094d18ed5c2739302"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.10"
+            "version": "==1.38.14"
         },
         "botocore": {
             "hashes": [
-                "sha256:5244454bb9e8fbb6510145d1554e82fd243e8583507d83077ecf4f8efb66cb46",
-                "sha256:c531c13803e0fad5b395c5ccab4c11ac88acfccde71c9b998df6fa841392a8fc"
+                "sha256:3125ed92e9ee6137c28fd32c56934a531a372346a7b13cb86de4328d7629e156",
+                "sha256:8ac91de6c33651a5c699268f1d22fadd5e99f370230dbea97d29e4164de4e5f2"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.10"
+            "version": "==1.38.14"
         },
         "certifi": {
             "hashes": [
@@ -228,21 +228,21 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:90f4f883f9eff294aff59af3d58c2d1b64e3927b28d5ada2b9b41f5aeda47daf",
-                "sha256:c58935bfff8af6a0856d37e8adebdbc7b3281c2b632ec823ef03cd108d216ff0"
+                "sha256:14d2b73bc93afaf2a9412490329099e6217761cbab13b6ee8bc0e82927e1504e",
+                "sha256:51496e6cb3cb625b99c8e08907c67a9112360259b0ef08470e532c3ab184a232"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2.27.0"
+            "version": "==2.28.0"
         },
         "setuptools": {
             "hashes": [
-                "sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927",
-                "sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537"
+                "sha256:5a78f61820bc088c8e4add52932ae6b8cf423da2aff268c23f813cfbb13b4006",
+                "sha256:6cdc8cb9a7d590b237dbe4493614a9b75d0559b888047c1f67d49ba50fc3edb2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==80.3.1"
+            "version": "==80.4.0"
         },
         "six": {
             "hashes": [
@@ -545,11 +545,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
-                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+                "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c",
+                "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.8"
+            "markers": "python_version >= '3.10'",
+            "version": "==8.2.0"
         },
         "coverage": {
             "extras": [
@@ -966,11 +966,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94",
-                "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"
+                "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc",
+                "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.3.7"
+            "version": "==4.3.8"
         },
         "pluggy": {
             "hashes": [
@@ -1043,6 +1043,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==8.3.5"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
         },
         "pyyaml": {
             "hashes": [
@@ -1249,28 +1258,28 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:0eba551324733efc76116d9f3a0d52946bc2751f0cd30661564117d6fd60897c",
-                "sha256:161eb4cff5cfefdb6c9b8b3671d09f7def2f960cee33481dd898caf2bcd02304",
-                "sha256:258f3585057508d317610e8a412788cf726efeefa2fec4dba4001d9e6f90d46c",
-                "sha256:304432e4c4a792e3da85b7699feb3426a0908ab98bf29df22a31b0cdd098fac2",
-                "sha256:3dca977cc4fc8f66e89900fa415ffe4dbc2e969da9d7a54bfca81a128c5ac219",
-                "sha256:4d9aaa91035bdf612c8ee7266153bcf16005c7c7e2f5878406911c92a31633cb",
-                "sha256:5b18caa297a786465cc511d7f8be19226acf9c0a1127e06e736cd4e1878c3ea2",
-                "sha256:6d742d10626f9004b781f4558154bb226620a7242080e11caeffab1a40e99df8",
-                "sha256:6e70d11043bef637c5617297bdedec9632af15d53ac1e1ba29c448da9341b0c4",
-                "sha256:727d01702f7c30baed3fc3a34901a640001a2828c793525043c29f7614994a8c",
-                "sha256:7f024d32e62faad0f76b2d6afd141b8c171515e4fb91ce9fd6464335c81244e5",
-                "sha256:896a37516c594805e34020c4a7546c8f8a234b679a7716a3f08197f38913e1a3",
-                "sha256:ab86d22d3d721a40dd3ecbb5e86ab03b2e053bc93c700dc68d1c3346b36ce835",
-                "sha256:c1dba3135ca503727aa4648152c0fa67c3b1385d3dc81c75cd8a229c4b2a1458",
-                "sha256:c657fa987d60b104d2be8b052d66da0a2a88f9bd1d66b2254333e84ea2720c7f",
-                "sha256:d365618d3ad747432e1ae50d61775b78c055fee5936d77fb4d92c6f559741948",
-                "sha256:f2e74b021d0de5eceb8bd32919f6ff8a9b40ee62ed97becd44993ae5b9949474",
-                "sha256:f9b5ef39820abc0f2c62111f7045009e46b275f5b99d5e59dda113c39b7f4f38"
+                "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7",
+                "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381",
+                "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964",
+                "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70",
+                "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de",
+                "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722",
+                "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787",
+                "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65",
+                "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a",
+                "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6",
+                "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c",
+                "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca",
+                "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1",
+                "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd",
+                "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b",
+                "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517",
+                "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271",
+                "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.8"
+            "version": "==0.11.9"
         },
         "sortedcontainers": {
             "hashes": [
@@ -1329,11 +1338,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:65442939608aeebb9284cd30baca5865fcd9f12b58bb740a24b220030df46d26",
-                "sha256:f448cd2f1604c831afb9ea238021060be2c0edbcad8eb0a4e8b4e14ff11a5482"
+                "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11",
+                "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.31.1"
+            "version": "==20.31.2"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -88,5 +88,5 @@ CHALLENGE_SECRET=### Secret string that is passed as part of lambda invocation p
 ### Optional
 
 ```shell
-None yet...
+WORKSPACE_ROOT_DIR=### Root directory where Bagit zip files will be temporarily created, then cleaned up; for deployed Lambda this will be the EFS mount.  Defaults to /tmp.
 ```

--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ CHALLENGE_SECRET=### Secret string that is passed as part of lambda invocation p
 
 ```shell
 WARNING_ONLY_LOGGERS=### comma separated list of libraries to limit to WARNING logging level
-WORKSPACE_ROOT_DIR=### Root directory where Bagit zip files will be temporarily created, then cleaned up; for deployed Lambda this will be the EFS mount.  Defaults to /tmp.
+BAGIT_WORKING_DIR=### Root directory where Bagit zip files will be temporarily created, then cleaned up; for deployed Lambda this will be the EFS mount.  Defaults to /tmp.
 ```

--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@ CHALLENGE_SECRET=### Secret string that is passed as part of lambda invocation p
 ### Optional
 
 ```shell
+WARNING_ONLY_LOGGERS=### comma separated list of libraries to limit to WARNING logging level
 WORKSPACE_ROOT_DIR=### Root directory where Bagit zip files will be temporarily created, then cleaned up; for deployed Lambda this will be the EFS mount.  Defaults to /tmp.
 ```

--- a/apt/bagit_archive.py
+++ b/apt/bagit_archive.py
@@ -16,7 +16,7 @@ CONFIG = Config()
 
 
 class BagitArchive:
-    """Class for creating a Bagit archive files."""
+    """Class for creating a Bagit archive zip file."""
 
     DEFAULT_CHECKSUMS: ClassVar[list[str]] = [
         "md5",
@@ -47,6 +47,11 @@ class BagitArchive:
     ) -> dict[str, Any]:
         """Create a new Bagit archive zip file and save to the specified URI.
 
+        A temporary directory will be created for the Bag, which will then be zipped up,
+        and fully removed after copying to target destination.  The workspace for where
+        this temporary directory will be created is defined by CONFIG.workspace_root_dir.
+        For the deployed Lambda, the root workspace will be the connected EFS mount.
+
         Args:
             input_files: List of dicts with 'uri', 'filepath', and optional 'checksums'
             output_zip_uri: URI where to save the final zip file (local path or s3://bucket/key)
@@ -62,9 +67,9 @@ class BagitArchive:
         }
 
         try:
-            # NOTE: Eventually this TemporaryDirectory will be explicitly located in the
-            #   Lambda's EFS mount
-            with tempfile.TemporaryDirectory() as temp_bag_dir:
+            with tempfile.TemporaryDirectory(
+                dir=CONFIG.workspace_root_dir
+            ) as temp_bag_dir:
                 temp_dir_path = Path(temp_bag_dir)
 
                 # download input files

--- a/apt/bagit_archive.py
+++ b/apt/bagit_archive.py
@@ -49,7 +49,7 @@ class BagitArchive:
 
         A temporary directory will be created for the Bag, which will then be zipped up,
         and fully removed after copying to target destination.  The workspace for where
-        this temporary directory will be created is defined by CONFIG.workspace_root_dir.
+        this temporary directory will be created is defined by CONFIG.bagit_working_dir.
         For the deployed Lambda, the root workspace will be the connected EFS mount.
 
         Args:
@@ -68,7 +68,7 @@ class BagitArchive:
 
         try:
             with tempfile.TemporaryDirectory(
-                dir=CONFIG.workspace_root_dir
+                dir=CONFIG.bagit_working_dir
             ) as temp_bag_dir:
                 temp_dir_path = Path(temp_bag_dir)
 

--- a/apt/config.py
+++ b/apt/config.py
@@ -38,6 +38,19 @@ class Config:
             return dsn
         return None
 
+    @property
+    def workspace_root_dir(self) -> str:
+        """Root workspace directory where temporary directories will be created.
+
+        Locally, this defaults to '/tmp'.  For deployed Lambda, this will default to the
+        EFS mount connected to the Lambda.
+
+        This workspace directory is expected to persist, but all files and directories
+        created here over the course of creating the Bagit zip file are designed to be
+        temporary.
+        """
+        return os.getenv("WORKSPACE_ROOT_DIR", "/tmp")  # noqa: S108
+
 
 def configure_logger(
     root_logger: logging.Logger,

--- a/apt/config.py
+++ b/apt/config.py
@@ -15,7 +15,10 @@ class Config:
         "SENTRY_DSN",
         "CHALLENGE_SECRET",
     )
-    OPTIONAL_ENV_VARS = ()
+    OPTIONAL_ENV_VARS = (
+        "WARNING_ONLY_LOGGERS",
+        "WORKSPACE_ROOT_DIR",
+    )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
         """Provide dot notation access to configurations and env vars on this class."""

--- a/apt/config.py
+++ b/apt/config.py
@@ -17,7 +17,7 @@ class Config:
     )
     OPTIONAL_ENV_VARS = (
         "WARNING_ONLY_LOGGERS",
-        "WORKSPACE_ROOT_DIR",
+        "BAGIT_WORKING_DIR",
     )
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
@@ -42,7 +42,7 @@ class Config:
         return None
 
     @property
-    def workspace_root_dir(self) -> str:
+    def bagit_working_dir(self) -> str:
         """Root workspace directory where temporary directories will be created.
 
         Locally, this defaults to '/tmp'.  For deployed Lambda, this will default to the
@@ -52,7 +52,7 @@ class Config:
         created here over the course of creating the Bagit zip file are designed to be
         temporary.
         """
-        return os.getenv("WORKSPACE_ROOT_DIR", "/tmp")  # noqa: S108
+        return os.getenv("BAGIT_WORKING_DIR", "/tmp")  # noqa: S108
 
 
 def configure_logger(

--- a/apt/utils.py
+++ b/apt/utils.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from smart_open import smart_open  # type: ignore[import]
+from smart_open import open  # type: ignore[import] # noqa: A004
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +34,7 @@ def stream_file_transfer(
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
     total_bytes = 0
-    with smart_open(source_uri, "rb") as source_file, smart_open(
-        target_uri, "wb"
-    ) as target_file:
+    with open(source_uri, "rb") as source_file, open(target_uri, "wb") as target_file:
         while True:
             chunk = source_file.read(chunk_size)
             if not chunk:

--- a/tests/test_bagit_archive.py
+++ b/tests/test_bagit_archive.py
@@ -1,4 +1,5 @@
 import shutil
+import tempfile
 import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -31,6 +32,20 @@ class TestBagitArchive:
                 },
             }
         ]
+
+    @pytest.fixture
+    def test_workspace_root_dir(self, tmp_path, monkeypatch) -> Path:
+        test_workspace = tmp_path / "test_workspace"
+        test_workspace.mkdir()
+        monkeypatch.setenv("WORKSPACE_ROOT_DIR", str(test_workspace))
+        return test_workspace
+
+    @pytest.fixture
+    def patched_bagit_archive(self, mocker):
+        bagit_archive = BagitArchive()
+        mock_upload = mocker.patch("apt.bagit_archive.BagitArchive.upload_bag_to_s3")
+        mock_upload.return_value = "s3://fake-bucket/bag.zip"
+        return bagit_archive
 
     def test_init_defaults(self):
         bagit_archive = BagitArchive()
@@ -178,3 +193,39 @@ class TestBagitArchive:
             assert result["success"] is False
             assert result["error"] == "Test error"
             assert "elapsed" in result
+
+    def test_workspace_root_dir_cleaned_up_after_bagit_zip_creation(
+        self, test_workspace_root_dir, patched_bagit_archive
+    ):
+        patched_bagit_archive.process(
+            [{"uri": "tests/fixtures/sample.txt", "filepath": "sample.txt"}],
+            "s3://fake-bucket/bag.zip",
+        )
+
+        # assert that the custom workspace is empty, indicating that
+        # BagitArchive.process successfully cleaned up after the upload
+        assert list(test_workspace_root_dir.glob("*")) == []
+        assert list(test_workspace_root_dir.glob("**/*")) == []
+
+        # assert that the workspace remains
+        assert test_workspace_root_dir.exists()
+
+    def test_workspace_root_dir_used_for_temporary_bagit_directory(
+        self, test_workspace_root_dir, patched_bagit_archive, mocker
+    ):
+        # spy on tempfile.TemporaryDirectory to observe where it's created later
+        temp_dir_spy = mocker.spy(tempfile, "TemporaryDirectory")
+
+        patched_bagit_archive.process(
+            [{"uri": "tests/fixtures/sample.txt", "filepath": "sample.txt"}],
+            "s3://fake-bucket/bag.zip",
+        )
+
+        # assert tempfile.TemporaryDirectory() was called once to create a temporary
+        # Bagit directory in our test workspace
+        assert temp_dir_spy.call_count == 1
+
+        # assert that our test_workspace was the *root* of the temporary directory created
+        temp_dir_call_args = temp_dir_spy.call_args_list[0]
+        temp_dir_path = temp_dir_call_args[1].get("dir")
+        assert temp_dir_path.startswith(str(test_workspace_root_dir))

--- a/tests/test_bagit_archive.py
+++ b/tests/test_bagit_archive.py
@@ -34,10 +34,10 @@ class TestBagitArchive:
         ]
 
     @pytest.fixture
-    def test_workspace_root_dir(self, tmp_path, monkeypatch) -> Path:
+    def test_bagit_working_dir(self, tmp_path, monkeypatch) -> Path:
         test_workspace = tmp_path / "test_workspace"
         test_workspace.mkdir()
-        monkeypatch.setenv("WORKSPACE_ROOT_DIR", str(test_workspace))
+        monkeypatch.setenv("BAGIT_WORKING_DIR", str(test_workspace))
         return test_workspace
 
     @pytest.fixture
@@ -194,8 +194,8 @@ class TestBagitArchive:
             assert result["error"] == "Test error"
             assert "elapsed" in result
 
-    def test_workspace_root_dir_cleaned_up_after_bagit_zip_creation(
-        self, test_workspace_root_dir, patched_bagit_archive
+    def test_bagit_working_dir_cleaned_up_after_bagit_zip_creation(
+        self, test_bagit_working_dir, patched_bagit_archive
     ):
         patched_bagit_archive.process(
             [{"uri": "tests/fixtures/sample.txt", "filepath": "sample.txt"}],
@@ -204,14 +204,14 @@ class TestBagitArchive:
 
         # assert that the custom workspace is empty, indicating that
         # BagitArchive.process successfully cleaned up after the upload
-        assert list(test_workspace_root_dir.glob("*")) == []
-        assert list(test_workspace_root_dir.glob("**/*")) == []
+        assert list(test_bagit_working_dir.glob("*")) == []
+        assert list(test_bagit_working_dir.glob("**/*")) == []
 
         # assert that the workspace remains
-        assert test_workspace_root_dir.exists()
+        assert test_bagit_working_dir.exists()
 
-    def test_workspace_root_dir_used_for_temporary_bagit_directory(
-        self, test_workspace_root_dir, patched_bagit_archive, mocker
+    def test_bagit_working_dir_used_for_temporary_bagit_directory(
+        self, test_bagit_working_dir, patched_bagit_archive, mocker
     ):
         # spy on tempfile.TemporaryDirectory to observe where it's created later
         temp_dir_spy = mocker.spy(tempfile, "TemporaryDirectory")
@@ -228,4 +228,4 @@ class TestBagitArchive:
         # assert that our test_workspace was the *root* of the temporary directory created
         temp_dir_call_args = temp_dir_spy.call_args_list[0]
         temp_dir_path = temp_dir_call_args[1].get("dir")
-        assert temp_dir_path.startswith(str(test_workspace_root_dir))
+        assert temp_dir_path.startswith(str(test_bagit_working_dir))


### PR DESCRIPTION
### Purpose and background context

This PR updates the app to have a configurable "workspace" when creating Bagit zip files,  and by proxy, enable it to use and EFS filesystem that is mounted to the Lambda.  This allows the tool to create Bagit zip files that exceed the size of the Lambda's ephemeral storage.

While a Lambda's ephemeral storage can be extended up to 10gb, it's worth keeping in mind that **concurrent** requests to the same Lambda would share this space, even non-concurrent but sequential would as well when the lambda remains "hot".  Moreover, usage of the EFS mount opens up the door to applications writing files there directly for bagging up, saving the Lambda from downloading them from S3 (though not yet a known use case for this).

Code-wise, just needed a way to configure a root workspace where temporary directories are created and then removed from, which comes courtesy of the new env var `WORKSPACE_ROOT_DIR`.

### How can a reviewer manually see the effects of these changes?

Make a request to the deployed lambda, creating a bag for a 1gb file that would normally exceed the lambda's 512mb ephemeral storage (downloading of files + zipping it up).

```shell
curl --location '<GET FROM LAMBDA FUNCTION URL>' \
--header 'Content-Type: application/json' \
--data '{
    "action":"create-bagit-zip",
    "challenge_secret":"<GET FROM LAMBDA ENV VARS>",
    "verbose":true,
    "input_files": [
        {
            "filepath": "records.xml",
            "uri": "s3://ghukill-test/apt-testing/large-1gb-file.xml"           
        }
    ],
    "output_zip_s3_uri": "s3://ghukill-test/apt-testing/in-1230-1gb-file.zip",
    "compress_zip":false
}'
```

This request will take about 70 seconds, which is the time to:
  1. download the 1gb file to the Lambda EFS mount
  2. create the Bagit directory
  3. zip it up
  4. upload back to S3

This has been successfully tested up to 4gb, which further confirms EFS usage.  However, somewhat unrelated, a 12.2gb test is failing due to the lambda timing out at 15 minutes.  This is a known limitation of the lambda approach, and is a separate matter from the EFS mount; the _storage_ would have been sufficient.

### Includes new or updated dependencies?
YES: `pytest-mock` for "spying" on functions

### Changes expectations for external applications?
YES: by exposing this env var, the lamda is now capable of utilizing the EFS mount

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1230

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes