### PR TITLE
IN 1294 - Replace smart-open with direct boto3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ bagit = "*"
 boto3 = "*"
 sentry-sdk = "*"
 setuptools = "*"
-smart-open = {extras = ["s3"], version = "*"}
 jsonschema = "*"
 
 [dev-packages]
@@ -22,6 +21,7 @@ pytest = "*"
 ruff = "*"
 types-jsonschema = "*"
 pytest-mock = "*"
+boto3-stubs = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2560894c94f2c81c6f173a87ce0328a228c52290b389b59fa85159252a02565d"
+            "sha256": "72be346c030e12c5c84a9f08d28f01ca8bc223c6844d16889cc3f1dac81e5301"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -252,17 +252,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
-        "smart-open": {
-            "extras": [
-                "s3"
-            ],
-            "hashes": [
-                "sha256:4b8489bb6058196258bafe901730c7db0dcf4f083f316e97269c66f45502055b",
-                "sha256:a4f09f84f0f6d3637c6543aca7b5487438877a21360e7368ccf1f704789752ba"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==7.1.0"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
@@ -278,91 +267,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.4.0"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:08e7ce672e35efa54c5024936e559469436f8b8096253404faeb54d2a878416f",
-                "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c",
-                "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a",
-                "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b",
-                "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555",
-                "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c",
-                "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b",
-                "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6",
-                "sha256:1e1fe0e6ab7775fd842bc39e86f6dcfc4507ab0ffe206093e76d61cde37225c8",
-                "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662",
-                "sha256:2696993ee1eebd20b8e4ee4356483c4cb696066ddc24bd70bcbb80fa56ff9061",
-                "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998",
-                "sha256:36ccae62f64235cf8ddb682073a60519426fdd4725524ae38874adf72b5f2aeb",
-                "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62",
-                "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984",
-                "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392",
-                "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2",
-                "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306",
-                "sha256:410a92fefd2e0e10d26210e1dfb4a876ddaf8439ef60d6434f21ef8d87efc5b7",
-                "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3",
-                "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9",
-                "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6",
-                "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192",
-                "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317",
-                "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f",
-                "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda",
-                "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563",
-                "sha256:58455b79ec2661c3600e65c0a716955adc2410f7383755d537584b0de41b1d8a",
-                "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f",
-                "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d",
-                "sha256:5c803c401ea1c1c18de70a06a6f79fcc9c5acfc79133e9869e730ad7f8ad8ef9",
-                "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8",
-                "sha256:612dff5db80beef9e649c6d803a8d50c409082f1fedc9dbcdfde2983b2025b82",
-                "sha256:62c2caa1585c82b3f7a7ab56afef7b3602021d6da34fbc1cf234ff139fed3cd9",
-                "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845",
-                "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82",
-                "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125",
-                "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504",
-                "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b",
-                "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7",
-                "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc",
-                "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6",
-                "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40",
-                "sha256:91bd7d1773e64019f9288b7a5101f3ae50d3d8e6b1de7edee9c2ccc1d32f0c0a",
-                "sha256:95c658736ec15602da0ed73f312d410117723914a5c91a14ee4cdd72f1d790b3",
-                "sha256:99039fa9e6306880572915728d7f6c24a86ec57b0a83f6b2491e1d8ab0235b9a",
-                "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72",
-                "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681",
-                "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438",
-                "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae",
-                "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2",
-                "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb",
-                "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5",
-                "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a",
-                "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3",
-                "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8",
-                "sha256:b4e42a40a5e164cbfdb7b386c966a588b1047558a990981ace551ed7e12ca9c2",
-                "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22",
-                "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72",
-                "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061",
-                "sha256:ba0f0eb61ef00ea10e00eb53a9129501f52385c44853dbd6c4ad3f403603083f",
-                "sha256:bb87745b2e6dc56361bfde481d5a378dc314b252a98d7dd19a651a3fa58f24a9",
-                "sha256:bb90fb8bda722a1b9d48ac1e6c38f923ea757b3baf8ebd0c82e09c5c1a0e7a04",
-                "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98",
-                "sha256:c86563182421896d73858e08e1db93afdd2b947a70064b813d515d66549e15f9",
-                "sha256:c958bcfd59bacc2d0249dcfe575e71da54f9dcf4a8bdf89c4cb9a68a1170d73f",
-                "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b",
-                "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925",
-                "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6",
-                "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0",
-                "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9",
-                "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c",
-                "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991",
-                "sha256:ecc840861360ba9d176d413a5489b9a0aff6d6303d7e733e2c4623cfa26904a6",
-                "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000",
-                "sha256:f393cda562f79828f38a819f4788641ac7c4085f30f1ce1a68672baa686482bb",
-                "sha256:f917c1180fdb8623c2b75a99192f4025e412597c50b2ac870f156de8fb101119",
-                "sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b",
-                "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.17.2"
         }
     },
     "develop": {
@@ -417,6 +321,23 @@
                 "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9"
             ],
             "version": "==5.0"
+        },
+        "boto3-stubs": {
+            "hashes": [
+                "sha256:0be0b5857d080de92c6b40b35950c62224c50858b26a530cdebfad9802cd467f",
+                "sha256:b4c28839868f4a6b6d1004b2993f6054e33bc2c635eb6dd170ce93bb75842f4f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.38.15"
+        },
+        "botocore-stubs": {
+            "hashes": [
+                "sha256:db621e8378776e04716adcd61a13996ecd5574b6e46bec8ecc0c3054122a7a08",
+                "sha256:f84a6efc7b9554fecdf4d875909a28bc8bd63a7def23dd5ceadb5b7759ea0524"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.38.15"
         },
         "cachecontrol": {
             "extras": [
@@ -1311,6 +1232,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==5.14.3"
         },
+        "types-awscrt": {
+            "hashes": [
+                "sha256:3c2bee52ee45022daaf4f106d5d1b5f0ff0a8e3e6093dda65f5315b7669bc418",
+                "sha256:e86b83d0fd8c770f985b8c458c28e232dae9adee0689d0a9671868a8bf397b0a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.27.1"
+        },
         "types-jsonschema": {
             "hashes": [
                 "sha256:87934bd9231c99d8eff94cacfc06ba668f7973577a9bd9e1f9de957c5737313e",
@@ -1319,6 +1248,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.23.0.20241208"
+        },
+        "types-s3transfer": {
+            "hashes": [
+                "sha256:101bbc5b7f00b71512374df881f480fc6bf63c948b5098ab024bf3370fbfb0e8",
+                "sha256:f8f59201481e904362873bf0be3267f259d60ad946ebdfcb847d092a1fa26f98"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/apt/utils.py
+++ b/apt/utils.py
@@ -1,18 +1,21 @@
 import logging
+import re
+import shutil
 from pathlib import Path
 
-from smart_open import open  # type: ignore[import] # noqa: A004
+import boto3
+from boto3.s3.transfer import TransferConfig
 
 logger = logging.getLogger(__name__)
 
-# size in megabytes (x * 1024 * 1024 = megabytes)
-DEFAULT_CHUNK_SIZE = 50 * 1024 * 1024
+S3_PATTERN = r"s3://([^/]+)/(.+)"
 
 
 def stream_file_transfer(
     source_uri: str | Path,
     target_uri: str | Path,
-    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    max_concurrency: int = 10,
+    chunk_size: int = 100 * 1024 * 1024,  # 100MB
 ) -> str:
     """Stream file from source to target without loading entire file into memory.
 
@@ -21,25 +24,68 @@ def stream_file_transfer(
     Args:
         source_uri: Source URI or path to read from
         target_uri: Target URI or path to write to
-        chunk_size: Size of chunks to read/write in bytes
+        max_concurrency: Maximum number of concurrent threads for S3 transfers
+        chunk_size: Size of chunks for transfers in bytes
     """
     source_uri = str(source_uri)
     target_uri = str(target_uri)
 
     logger.debug(f"Streaming file from '{source_uri}' to '{target_uri}'")
 
-    # ensure parent directory exists for local target paths
-    if not target_uri.startswith("s3://"):
-        target_path = Path(target_uri)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
+    s3_client = boto3.client("s3")
+    transfer_config = TransferConfig(
+        multipart_threshold=chunk_size,
+        max_concurrency=max_concurrency,
+        multipart_chunksize=chunk_size,
+        use_threads=True,
+    )
 
-    total_bytes = 0
-    with open(source_uri, "rb") as source_file, open(target_uri, "wb") as target_file:
-        while True:
-            chunk = source_file.read(chunk_size)
-            if not chunk:
-                break
-            target_file.write(chunk)
-            total_bytes += len(chunk)
+    # S3-to-Local
+    if re.match(S3_PATTERN, source_uri) and not re.match(S3_PATTERN, target_uri):
+        source_bucket, source_key = parse_s3_uri(source_uri)
+        # create local directory if not present
+        Path(target_uri).parent.mkdir(parents=True, exist_ok=True)
+        s3_client.download_file(
+            Bucket=source_bucket,
+            Key=source_key,
+            Filename=target_uri,
+            Config=transfer_config,
+        )
 
+    # Local-to-S3
+    elif not re.match(S3_PATTERN, source_uri) and re.match(S3_PATTERN, target_uri):
+        target_bucket, target_key = parse_s3_uri(target_uri)
+        s3_client.upload_file(
+            Filename=source_uri,
+            Bucket=target_bucket,
+            Key=target_key,
+            Config=transfer_config,
+        )
+
+    # Local-to-Local
+    elif not re.match(S3_PATTERN, source_uri) and not re.match(S3_PATTERN, target_uri):
+        Path(target_uri).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source_uri, target_uri)
+
+    # S3-to-S3
+    else:
+        src_bucket, src_key = parse_s3_uri(source_uri)
+        target_bucket, target_key = parse_s3_uri(target_uri)
+        s3 = boto3.resource("s3")
+        s3.meta.client.copy(
+            {"Bucket": src_bucket, "Key": src_key},
+            target_bucket,
+            target_key,
+            Config=transfer_config,
+        )
+
+    logger.debug(f"Transfer completed from {source_uri} to {target_uri}")
     return target_uri
+
+
+def parse_s3_uri(s3_uri: str) -> tuple[str, str]:
+    match = re.match(S3_PATTERN, s3_uri)
+    if not match:
+        raise ValueError(f"Error parsing bucket and key from S3 URI: '{s3_uri}'")
+    bucket, key = match.groups()
+    return bucket, key

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+# ruff: noqa: S108
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apt.utils import parse_s3_uri, stream_file_transfer
+
+
+class TestStreamFileTransfer:
+    @patch("boto3.client")
+    def test_s3_to_local_transfer(self, mock_boto_client):
+        mock_s3_client = MagicMock()
+        mock_boto_client.return_value = mock_s3_client
+        source_uri = "s3://test-bucket/test-key"
+        target_uri = "/tmp/local-file"
+
+        result = stream_file_transfer(source_uri, target_uri)
+
+        mock_boto_client.assert_called_once_with("s3")
+        mock_s3_client.download_file.assert_called_once()
+        assert mock_s3_client.download_file.call_args[1]["Bucket"] == "test-bucket"
+        assert mock_s3_client.download_file.call_args[1]["Key"] == "test-key"
+        assert mock_s3_client.download_file.call_args[1]["Filename"] == target_uri
+        assert result == target_uri
+
+    @patch("boto3.client")
+    def test_local_to_s3_transfer(self, mock_boto_client):
+        mock_s3_client = MagicMock()
+        mock_boto_client.return_value = mock_s3_client
+        source_uri = "/tmp/local-file"
+        target_uri = "s3://test-bucket/test-key"
+
+        result = stream_file_transfer(source_uri, target_uri)
+
+        mock_boto_client.assert_called_once_with("s3")
+        mock_s3_client.upload_file.assert_called_once()
+        assert mock_s3_client.upload_file.call_args[1]["Filename"] == source_uri
+        assert mock_s3_client.upload_file.call_args[1]["Bucket"] == "test-bucket"
+        assert mock_s3_client.upload_file.call_args[1]["Key"] == "test-key"
+        assert result == target_uri
+
+    @patch("shutil.copyfile")
+    def test_local_to_local_transfer(self, mock_copyfile):
+        source_uri = "/tmp/source-file"
+        target_uri = "/tmp/target-file"
+
+        with patch("pathlib.Path.mkdir"):
+            result = stream_file_transfer(source_uri, target_uri)
+
+        mock_copyfile.assert_called_once_with(source_uri, target_uri)
+        assert result == target_uri
+
+    @patch("boto3.resource")
+    def test_s3_to_s3_transfer(self, mock_boto_resource):
+        mock_s3 = MagicMock()
+        mock_boto_resource.return_value = mock_s3
+        source_uri = "s3://source-bucket/source-key"
+        target_uri = "s3://target-bucket/target-key"
+
+        result = stream_file_transfer(source_uri, target_uri)
+
+        mock_boto_resource.assert_called_once_with("s3")
+        mock_s3.meta.client.copy.assert_called_once()
+        copy_args = mock_s3.meta.client.copy.call_args[0]
+        assert copy_args[0] == {"Bucket": "source-bucket", "Key": "source-key"}
+        assert copy_args[1] == "target-bucket"
+        assert copy_args[2] == "target-key"
+        assert result == target_uri
+
+
+class TestParseS3Uri:
+    def test_parse_valid_s3_uri(self):
+        bucket, key = parse_s3_uri("s3://test-bucket/test-key")
+        assert bucket == "test-bucket"
+        assert key == "test-key"
+
+    def test_parse_invalid_s3_uri(self):
+        with pytest.raises(ValueError, match="Error parsing bucket and key from S3 URI"):
+            parse_s3_uri("not-an-s3-uri")


### PR DESCRIPTION
### Purpose and background context

**Why these changes are being introduced:**

Some testing in Dev environment revealed that downloading and uploading of files from S3, via the utils function `stream_file_transfer()` was not as performant as it could be. For very large files in a Bag, this resulted in long Lambda runtimes that could exceed the 15 minute timeout.

**How this addresses that need:**

Instead of using `smart-open` to handle S3 or local files, the utility function `stream_file_transfer()` now detects the type of transfer, e.g. S3-to-Local, Local-to-S3, Local-to-Local, or S3-to-S3, and uses more tailored code and libraries for each.

Read/write times are notably faster now.  Observing 1gb file transfers taking anywhere from 15-20 seconds, which works out to **51 - 68 MB/s (megabytes per second)**.

Any remaining bottlenecks are likely related more to the Lambda's network throughput as governed by its memory setting ([they are unintuitively correlated](https://repost.aws/questions/QUV7aqLIEqTwuUvr9TY9dvoQ/does-lambda-memory-allocation-impact-network-bandwidth)) or the [EFS mount's throughput](https://docs.aws.amazon.com/efs/latest/ug/performance.html#throughput-modes).  Any improvements to those will be handled outside of code in infrastructure most likely.

### How can a reviewer manually see the effects of these changes?

Create a Bagit zip with a single 1gb XML file:

```shell
curl --location '<FUNCTIONAL URL FROM LAMBDA>' \
--header 'Content-Type: application/json' \
--data '{
    "action":"create-bagit-zip",
    "challenge_secret":"<CHALLENGE_SECRET FROM LAMBDA>",
    "verbose":true,
    "input_files": [
        {
            "filepath": "records.xml",
            "uri": "s3://ghukill-test/apt-testing/large-1gb-file.xml"           
        }
    ],
    "output_zip_s3_uri": "s3://ghukill-test/apt-testing/in-1294-1gb-file.zip",
    "compress_zip":false
}'
```

A snippet of the logs shows the decreased download / upload times  (don't have exact numbers for pre-changes times, but these are quicker):
```
...
17:18:09,151 DEBUG apt.utils.stream_file_transfer() line 33: Streaming file from 's3://ghukill-test/apt-testing/large-1gb-file.xml' to '/mnt/efs/tmp7r6pvb9k/records.xml'
17:18:28,022 INFO apt.utils.stream_file_transfer() line 82: Transfer completed from s3://ghukill-test/apt-testing/large-1gb-file.xml to /mnt/efs/tmp7r6pvb9k/records.xml
...
17:18:48,007 DEBUG apt.utils.stream_file_transfer() line 33: Streaming file from '/mnt/efs/tmp7r6pvb9k/bag.zip' to 's3://ghukill-test/apt-testing/in-1294-1gb-file.zip'
17:19:02,971 INFO apt.utils.stream_file_transfer() line 82: Transfer completed from /mnt/efs/tmp7r6pvb9k/bag.zip to s3://ghukill-test/apt-testing/in-1294-1gb-file.zip
```
- 19 seconds to download ~1gb XML file
- 14 seconds to upload ~1gb zip file

As noted above, this works matches our observed 51 - 68 MB/s for a 1gb file @ 15-20 seconds.

### Includes new or updated dependencies?
YES: removed `smart-open`

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1294

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes