### PR TITLE
ETD 669 - Remove default contact name from bag metadata

### DIFF
--- a/apt/bagit_archive.py
+++ b/apt/bagit_archive.py
@@ -27,7 +27,7 @@ class BagitArchive:
         self,
         bag_metadata: dict | None = None,
     ):
-        self.bag_metadata = bag_metadata or {"Contact-Name": "Default Contact"}
+        self.bag_metadata = bag_metadata or {}
         self.bag = None
 
     @property

--- a/tests/test_bagit_archive.py
+++ b/tests/test_bagit_archive.py
@@ -64,6 +64,10 @@ class TestBagitArchive:
             bagit_archive.download_file(str(sample_file_path), target_path)
             mock_transfer.assert_called_once_with(str(sample_file_path), target_path)
 
+    def test_init_no_metadata(self):
+        bagit_archive = BagitArchive()
+        assert bagit_archive.bag_metadata == {}
+
     def test_download_files(self, tmp_path, input_files):
         bagit_archive = BagitArchive()
 


### PR DESCRIPTION
### Purpose and background context

A placeholder value of `"Default Contact"` had remained in code for the bag metadata of `"Contact-Name"`.

How this addresses that need:
* This default is removed.

### How can a reviewer manually see the effects of these changes?

See new test `test_init_no_metadata()`.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Bags without explicit metadata will not have "Contact-Name=Default Contact"

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ETD-669

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes